### PR TITLE
add sight cards with styleguide

### DIFF
--- a/client/src/components/SightCard.md
+++ b/client/src/components/SightCard.md
@@ -1,0 +1,16 @@
+```jsx
+import { useState } from 'react';
+
+const [sight, setSight] = useState({
+  name: 'Cliffs of Moher',
+  county: 'Clare',
+  imgUrl:
+    'https://lh5.googleusercontent.com/p/AF1QipO1yJ6Mnu30SqAt69GxC4t3sMfestLPlS4i11_9=w408-h272-k-no',
+});
+
+<SightCard
+  sight={sight}
+  isFave={(sight) => false}
+  toggleFavorite={() => alert('Added to Favorites!')}
+/>;
+```


### PR DESCRIPTION
PR #2 Implemented cards for all sights with option to mark as favourite by clicking on the shamrock icon. the logic for the info button has not yet been implemented. thanks :)