### PR TITLE
connect calendar logic to itinerary page and render sights on corresponding dates

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4737,18 +4737,6 @@
         }
       }
     },
-    "clipboard": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "clipboard-copy": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-3.2.0.tgz",
@@ -6242,13 +6230,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
-      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -8556,16 +8537,6 @@
       "dev": true,
       "requires": {
         "sparkles": "^1.0.0"
-      }
-    },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -15852,13 +15823,10 @@
       }
     },
     "prismjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "dev": true,
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+      "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ==",
+      "dev": true
     },
     "private": {
       "version": "0.1.8",
@@ -17473,13 +17441,6 @@
         "ajv-keywords": "^3.5.2"
       }
     },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
-      "optional": true
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -18765,13 +18726,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
-    },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
-      "optional": true
     },
     "tiny-invariant": {
       "version": "1.1.0",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -12,7 +12,7 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;800&display=swap"
       rel="stylesheet"
     />
     <link

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,7 +17,10 @@ function App() {
     loadFromLocal('Favourite Sights') ?? []
   );
   const [showCalendar, setShowCalendar] = useState(false);
-  const [selectDate, setSelectDate] = useState('');
+  const [selectDate, setSelectDate] = useState('28/6/2021');
+  const [dateSightCombos, setDateSightCombos] = useState(
+    loadFromLocal('Sights on Dates') ?? []
+  );
 
   useEffect(() => {
     fetch('/api/sights')
@@ -39,6 +42,10 @@ function App() {
   useEffect(() => {
     saveToLocal('Favourite Sights', faveSights);
   }, [faveSights]);
+
+  useEffect(() => {
+    saveToLocal('Sights on Dates', dateSightCombos);
+  }, [dateSightCombos]);
 
   function toggleFavorite(sightToToggle) {
     isFave(sightToToggle)
@@ -95,10 +102,15 @@ function App() {
               toggleCalendar={toggleCalendar}
               onSetSelectDate={setSelectDate}
               selectDate={selectDate}
+              dateSightCombos={dateSightCombos}
+              setDateSightCombos={setDateSightCombos}
             />
           </Route>
           <Route path='/itinerary'>
-            <Itinerary />
+            <Itinerary
+              dateSightCombos={dateSightCombos}
+              setDateSightCombos={setDateSightCombos}
+            />
           </Route>
         </Switch>
       </MainContainer>

--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -10,6 +10,8 @@ export default function Calendar({
   selectDate,
   onSetSelectDate,
   sight,
+  dateSightCombos,
+  setDateSightCombos,
 }) {
   const totalDaysOfEachMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
   const totalDaysOfEachMonthIfLeapYear = [
@@ -37,7 +39,6 @@ export default function Calendar({
   const [month, setMonth] = useState(date.getMonth());
   const [year, setYear] = useState(date.getFullYear());
   const [startDay, setStartDay] = useState(getStartDayOfMonth(date));
-  const [dateSightCombos, setDateSightCombos] = useState([]);
 
   useEffect(() => {
     setDay(date.getDate());
@@ -60,26 +61,8 @@ export default function Calendar({
     : totalDaysOfEachMonth;
 
   function handleModalOK() {
-    /*     if (dateSightCombos.some((combo) => combo.date === selectDate)) {
-      setDateSightCombos({
-        ...dateSightCombos,
-        date: [...dateSightCombos.date, sight.name],
-      });
-    } else { */
-    /*     setDateSightCombos([
-      ...dateSightCombos,
-      {
-        date: selectDate,
-        sight: sight.name,
-      },
-    ]); */
-    //}
-    let allCombos = dateSightCombos;
-    let newCombo = { date: selectDate, sight: sight.name };
-    allCombos.push(newCombo);
-    setDateSightCombos(...dateSightCombos, allCombos);
-
-    console.log(selectDate, sight.name, dateSightCombos);
+    const newCombo = { date: selectDate, sight: sight };
+    setDateSightCombos([...dateSightCombos, newCombo]);
     onSetShowCalendar(false);
   }
 
@@ -108,7 +91,13 @@ export default function Calendar({
               .fill(null)
               .map((_, index) => {
                 const d = index - (startDay - 2);
-                const formatted = `${d}/${month + 1}/${year}`;
+                const dFormatted =
+                  d.toString().length === 1 ? '0' + d.toString() : d;
+                const monthFormatted =
+                  (month + 1).toString().length === 1
+                    ? '0' + (month + 1).toString()
+                    : month + 1;
+                const formatted = `${dFormatted}/${monthFormatted}/${year}`;
                 return (
                   <Day
                     key={index}
@@ -142,6 +131,8 @@ Calendar.propTypes = {
   selectDate: PropTypes.string,
   onSetSelectDate: PropTypes.func,
   sight: PropTypes.object,
+  dateSightCombos: PropTypes.array,
+  setDateSightCombos: PropTypes.func,
 };
 
 const Modal = styled.div`

--- a/client/src/components/Calendar.md
+++ b/client/src/components/Calendar.md
@@ -1,0 +1,18 @@
+```jsx
+import { useState } from 'react';
+
+const [showCalendar, setShowCalendar] = useState(false);
+
+<>
+  <button onClick={() => setShowCalendar(!showCalendar)}>Show Calendar</button>
+
+  {showCalendar && (
+    <Calendar
+      isCalendarOpen={showCalendar}
+      onSetShowCalendar={() => setShowCalendar(!showCalendar)}
+      onSetSelectDate={() => alert('Date selected!')}
+      sight={{ name: 'not important' }}
+    />
+  )}
+</>;
+```

--- a/client/src/components/DetailsView.js
+++ b/client/src/components/DetailsView.js
@@ -15,6 +15,8 @@ export default function DetailsView({
   toggleCalendar,
   onSetSelectDate,
   selectDate,
+  dateSightCombos,
+  setDateSightCombos,
 }) {
   const [detailedSight, setDetailedSight] = useState({});
 
@@ -40,6 +42,8 @@ export default function DetailsView({
           onSetSelectDate={onSetSelectDate}
           selectDate={selectDate}
           sight={detailedSight}
+          dateSightCombos={dateSightCombos}
+          setDateSightCombos={setDateSightCombos}
         />
       )}
       <p>{detailedSight.description}</p>
@@ -73,6 +77,8 @@ DetailsView.propTypes = {
   onSetShowCalendar: PropTypes.func,
   toggleCalendar: PropTypes.func,
   onSetSelectDate: PropTypes.func,
+  dateSightCombos: PropTypes.array,
+  setDateSightCombos: PropTypes.func,
 };
 
 const DetailsWrapper = styled.div`
@@ -96,7 +102,7 @@ const DetailsWrapper = styled.div`
   }
 
   span {
-    text-decoration: underline;
+    font-weight: 600;
   }
 `;
 

--- a/client/src/components/Header.md
+++ b/client/src/components/Header.md
@@ -1,3 +1,7 @@
 ```jsx
-<Header />
+import { BrowserRouter as Router } from 'react-router-dom';
+
+<Router>
+  <Header />
+</Router>;
 ```

--- a/client/src/components/SightCard.js
+++ b/client/src/components/SightCard.js
@@ -52,7 +52,11 @@ const CardWrapper = styled.section`
   }
 `;
 
-const InfoWrapper = styled.div``;
+const InfoWrapper = styled.div`
+  h4 {
+    font-weight: 400;
+  }
+`;
 
 const IconWrapper = styled.div`
   display: flex;

--- a/client/src/pages/Itinerary.js
+++ b/client/src/pages/Itinerary.js
@@ -33,7 +33,9 @@ export default function Itinerary({ dateSightCombos, setDateSightCombos }) {
 
   function removeFromItinerary(comboToRemove) {
     const remaining = dateSightCombos.filter(
-      (combo) => combo.sight._id !== comboToRemove.sight._id
+      (combo) =>
+        (combo.sight._id && combo.date) !==
+        (comboToRemove.sight._id && comboToRemove.date)
     );
     setDateSightCombos(remaining);
   }

--- a/client/src/pages/Itinerary.js
+++ b/client/src/pages/Itinerary.js
@@ -32,13 +32,15 @@ export default function Itinerary({ dateSightCombos, setDateSightCombos }) {
   }, [dateSightCombos]);
 
   function removeFromItinerary(comboToRemove) {
+    console.log(comboToRemove);
     const remaining = dateSightCombos.filter(
       (combo) =>
-        (combo.sight._id && combo.date) !==
-        (comboToRemove.sight._id && comboToRemove.date)
+        combo.sight._id !== comboToRemove.sight._id ||
+        combo.date !== comboToRemove.date
     );
     setDateSightCombos(remaining);
   }
+  console.log(dateSightCombos);
 
   return (
     <>

--- a/client/src/pages/Itinerary.js
+++ b/client/src/pages/Itinerary.js
@@ -1,5 +1,113 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import styled from 'styled-components/macro';
 import { Headline } from './Sights';
 
-export default function Itinerary() {
-  return <Headline>My Itinerary</Headline>;
+import deleteIcon from '../images/delete.svg';
+import infoIcon from '../images/info.svg';
+
+export default function Itinerary({ dateSightCombos, setDateSightCombos }) {
+  const [dates, setDates] = useState([]);
+
+  useEffect(() => {
+    function getDatesForItinerary() {
+      const allDates = dateSightCombos.map((combo) => combo.date);
+      let uniqueDates = [];
+      const map = {};
+      allDates.forEach((date) => {
+        if (!map[JSON.stringify(date)]) {
+          map[JSON.stringify(date)] = true;
+          uniqueDates.push(date);
+          uniqueDates.sort((a, b) => {
+            a = a.split('/');
+            b = b.split('/');
+            return a[2] - b[2] || a[1] - b[1] || a[0] - b[0];
+          });
+        }
+      });
+      return uniqueDates;
+    }
+    setDates(getDatesForItinerary());
+  }, [dateSightCombos]);
+
+  function removeFromItinerary(comboToRemove) {
+    const remaining = dateSightCombos.filter(
+      (combo) => combo.sight._id !== comboToRemove.sight._id
+    );
+    setDateSightCombos(remaining);
+  }
+
+  return (
+    <>
+      <Headline>My Itinerary</Headline>
+      <ItineraryWrapper>
+        {dateSightCombos.length === 0 ? (
+          <h4 style={{ textAlign: 'center' }}>No sights added yet ☘️</h4>
+        ) : (
+          dates.map((date) => {
+            return (
+              <DateSightWrapper key={date}>
+                <h4>{date}</h4>
+                {dateSightCombos
+                  .filter((combo) => combo.date === date)
+                  .map((combo) => (
+                    <Sight key={combo.date + '+' + combo.sight._id}>
+                      <p>{combo.sight.name}</p>
+                      <IconWrapper>
+                        <Link to={`/sights/${combo.sight._id}`}>
+                          <img src={infoIcon} alt='See details' />
+                        </Link>
+                        <img
+                          src={deleteIcon}
+                          alt='Delete from itinerary'
+                          onClick={() => removeFromItinerary(combo)}
+                        />
+                      </IconWrapper>
+                    </Sight>
+                  ))}
+              </DateSightWrapper>
+            );
+          })
+        )}
+      </ItineraryWrapper>
+    </>
+  );
 }
+
+Itinerary.propTypes = {
+  dateSightCombos: PropTypes.array,
+  setDateSightCombos: PropTypes.func,
+};
+
+const ItineraryWrapper = styled.div`
+  border-radius: 20px;
+  margin: 0.8rem 0;
+  padding: 0.5rem 1rem;
+  background-color: var(--grey-lightest-opa);
+`;
+
+const DateSightWrapper = styled.article`
+  margin: 1rem 0;
+
+  h4 {
+    color: var(--primary-darkest);
+    letter-spacing: 0.06rem;
+  }
+`;
+
+const Sight = styled.section`
+  margin-top: 0.5rem;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+`;
+
+const IconWrapper = styled.div`
+  display: inline-flex;
+  justify-content: flex-end;
+  gap: 1.2rem;
+
+  img {
+    height: 1.8rem;
+  }
+`;


### PR DESCRIPTION
helloooo, this time I have added the logic from the calendar to the Itinerary page. on selecting a date for a specific sight, the sight will get rendered on the Itinerary page under the corresponding date. if several sights get added to one date, the date only gets rendered once with all sights below. you can also get to the sight's details view from there and delete it. the dates are shown in chronological order.
please note: you can add one sight to the itinerary more than once. on clicking on the delete icon, only that one entry will be deleted.
review link: https://adventeire-feat-itinera-rtkz3g.herokuapp.com/
please check in mobile view only!!
thanks a mill (: ✨ ☘️ 